### PR TITLE
Requester credentials are conditionally included in the XML request body

### DIFF
--- a/lib/ebayr/request.rb
+++ b/lib/ebayr/request.rb
@@ -47,11 +47,20 @@ module Ebayr #:nodoc:
       <<-XML
         <?xml version="1.0" encoding="utf-8"?>
         <#{@command}Request xmlns="urn:ebay:apis:eBLBaseComponents">
-          <RequesterCredentials>
-            <eBayAuthToken>#{@auth_token}</eBayAuthToken>
-          </RequesterCredentials>
+          #{requester_credentials_xml}
           #{input_xml}
         </#{@command}Request>
+      XML
+    end
+
+    # Returns eBay requester credential XML if @auth_token is present
+    def requester_credentials_xml
+      return "" unless @auth_token && !@auth_token.empty?
+
+      <<-XML
+      <RequesterCredentials>
+        <eBayAuthToken>#{@auth_token}</eBayAuthToken>
+      </RequesterCredentials>
       XML
     end
 

--- a/test/ebayr/request_test.rb
+++ b/test/ebayr/request_test.rb
@@ -55,5 +55,21 @@ describe Ebayr::Request do
       args = [{ :a => 1 }, { :a => [{:b => 1 }, { :b => 2 }] }]
       request(*args).must_equal '<a>1</a><a><b>1</b><b>2</b></a>'
     end
+
+    describe "requester credentials" do
+      it 'includes requester credentials when auth_token present' do
+        my_token = "auth-token-123xyz"
+        request = Ebayr::Request.new(:Blah, :auth_token => my_token)
+        request.body.must_include "<RequesterCredentials>", "</RequesterCredentials>"
+        request.body.must_include "<eBayAuthToken>#{my_token}</eBayAuthToken>"
+      end
+
+      it 'excludes requester credentials when auth_token not present' do
+        request = Ebayr::Request.new(:Blah, :auth_token => nil)
+        request.body.wont_include "<RequesterCredentials>", "</RequesterCredentials>"
+        request.body.wont_include "<eBayAuthToken>", "</eBayAuthToken>"
+      end
+    end
   end
+
 end


### PR DESCRIPTION
... only if an auth token is present.

The problem is that sending empty requester credentials for a request that doesn’t require them can cause that request to fail, e.g. `GetSessionID`.

For example:
```xml
<?xml version="1.0" encoding="utf-8"?>
    <GetSessionIDRequest xmlns="urn:ebay:apis:eBLBaseComponents">
    <RequesterCredentials>
        <eBayAuthToken></eBayAuthToken>
    </RequesterCredentials>
    <RuName>MY_RUNAME</RuName>
</GetSessionIDRequest>
```

Returns:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<GetSessionIDResponse 
    xmlns="urn:ebay:apis:eBLBaseComponents">
    <Timestamp>2015-07-04T06:29:40.490Z</Timestamp>
    <Ack>Failure</Ack>
    <Errors>
        <ShortMessage>Auth token is invalid.</ShortMessage>
        <LongMessage>Validation of the authentication token in API request failed.</LongMessage>
        <ErrorCode>931</ErrorCode>
        <SeverityCode>Error</SeverityCode>
        <ErrorClassification>RequestError</ErrorClassification>
    </Errors>
    <Version>921</Version>
    <Build>E921_CORE_API_17506731_R1</Build>
</GetSessionIDResponse>
```

Whereas
```xml
<?xml version="1.0" encoding="utf-8"?>
  <GetSessionIDRequest xmlns="urn:ebay:apis:eBLBaseComponents">
  <RuName>MY_RUNAME</RuName>
</GetSessionIDRequest>
```
Returns:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<GetSessionIDResponse 
    xmlns="urn:ebay:apis:eBLBaseComponents">
    <Timestamp>2015-07-04T06:31:59.657Z</Timestamp>
    <Ack>Success</Ack>
    <Version>929</Version>
    <Build>E929_CORE_APISIGNIN_17569042_R1</Build>
    <SessionID>L94CAA**57c3b1a914e0a624f91002c0ffffeb6e</SessionID>
</GetSessionIDResponse>
```