### PR TITLE
Allow to add attributes to tags

### DIFF
--- a/lib/ebayr/request.rb
+++ b/lib/ebayr/request.rb
@@ -19,7 +19,7 @@ module Ebayr #:nodoc:
       # Remaining options are converted and used as input to the call
       @input = options.delete(:input) || options
     end
-    
+
     def input_xml
       self.class.xml(@input)
     end
@@ -98,11 +98,29 @@ module Ebayr #:nodoc:
     def self.xml(*args)
       args.map do |structure|
         case structure
-          when Hash then structure.map { |k, v| "<#{k.to_s}>#{xml(v)}</#{k.to_s}>" }.join
+          when Hash then serialize_hash(structure)
           when Array then structure.map { |v| xml(v) }.join
           else self.serialize_input(structure).to_s
         end
       end.join
+    end
+
+    def self.serialize_hash(hash)
+      hash.map do |k, v|
+        if v.kind_of?(Hash) && v.key?(:value) && v.key?(:attr)
+          serialize_hash_with_attr(k, v)
+        else
+          "<#{k.to_s}>#{xml(v)}</#{k.to_s}>"
+        end
+      end.join
+    end
+
+    # Converts a hash with attributes to a tag
+    # {:foo=>{:value=>"Bar", :attr=>{:name=>"baz"}}}
+    # gives <foo name="baz">Bar</foo>
+    def self.serialize_hash_with_attr(key, value)
+      attr = value[:attr].map { |k_attr, v_attr| "#{k_attr}=\"#{v_attr}\"" }.join
+      "<#{key.to_s} #{attr}>#{xml(value[:value])}</#{key.to_s}>"
     end
 
     # Prepares an argument for input to an eBay Trading API XML call.

--- a/test/ebayr/request_test.rb
+++ b/test/ebayr/request_test.rb
@@ -39,6 +39,11 @@ describe Ebayr::Request do
       request(:a => { :b => 123 }).must_equal '<a><b>123</b></a>'
     end
 
+    it "converts a hash with attributes" do
+      hash = { :b => { :value => 123, :attr => { :name => 'c' } } }
+      request(hash).must_equal '<b name="c">123</b>'
+    end
+
     it "converts an array" do
       request([{ :a => 1 }, { :a => 2 }]).must_equal "<a>1</a><a>2</a>"
     end


### PR DESCRIPTION
This PR is related to issue #23 .

This allow to do `Ebayr::Request.new(:AddOrder, input: [{ Order: { CreatingUserRole: 'Buyer', 'Total' => { value: 100, attr: { currencyID: 'EUR' } } } }]).send`.

It will produce a body like this `<Order><CreatingUserRole>Buyer</CreatingUserRole><Total currencyID=\"EUR\">100</Total></Order>` as specified in [the doc](http://developer.ebay.com/devzone/XML/docs/Reference/eBay/AddOrder.html#AddOrder).
