### PR TITLE
new feature about input array

### DIFF
--- a/lib/ebayr/request.rb
+++ b/lib/ebayr/request.rb
@@ -98,7 +98,17 @@ module Ebayr #:nodoc:
     def self.xml(*args)
       args.map do |structure|
         case structure
-          when Hash then structure.map { |k, v| "<#{k.to_s}>#{xml(v)}</#{k.to_s}>" }.join
+          when Hash then structure.map { |k ,v|
+            str = ''
+            if v.class == Array
+              v.each do |item|
+                str += "<#{k.to_s}>#{xml(item)}</#{k.to_s}>"
+              end
+            else
+              str "<#{k.to_s}>#{xml(v)}</#{k.to_s}>"
+            end
+            str
+          }.join
           when Array then structure.map { |v| xml(v) }.join
           else self.serialize_input(structure).to_s
         end


### PR DESCRIPTION
>when you input {foo:[1,2,3]},you will get <foo>1</foo><foo>2</foo><foo>3</foo>,not <foo>123</foo>. about eBay API interface many tabs are using same tab names.
````
e.g.
<PictureDetails>
    <PictureURL>picture url</PictureURL>
    <PictureURL>picture url</PictureURL>
    <PictureURL>picture url</PictureURL>
</PictureDetails>
````
>current version cannnot provide feature like this, its output <foo>123</foo>